### PR TITLE
Bug/fix get state

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,43 @@ https://larsbergqvist.wordpress.com/2016/11/03/preparing-the-remote-control-app-
 
 ![Alt text](https://larsbergqvist.files.wordpress.com/2016/05/remote_and_iphoneapp.jpg?w=660 "Remote control")
 
+Testing the Flask application (smth like a dev environment)
+
+1. Create a local directory for example ~/git
+
+2. Navigate to the newly created dir
+
+cd git/
+
+3. Clone the repo
+
+sudo git clone https://github.com/andreimoraru/RemoteControlled_Outlets.git
+
+cd RemoteControlled_Outlets/
+
+4. Have a look at the existing remote branches
+
+sudo git branch -r
+
+5. Checkout to the required branch:
+
+sudo git checkout feature/multiple-lights-at-once
+
+6. If virtual environment exists, then skip this step. If not, proceed with it.
+
+sudo virtualenv venv
+
+7. activate virtual environment
+
+source venv/bin/activate
+
+8. Run the project. The command will keep the shell busy while running. You can open another shell over another SSH connection
+sudo python3 RemoteControlApp/remotecontrol.py
+
+9. Check the logs:
+tail -f /tmp/remotecontrol.log
+
+
 Enable the Python Redis Queue worker
 
 1. Edit rqworker@.service file

--- a/RemoteControlApp/remotecontrol.py
+++ b/RemoteControlApp/remotecontrol.py
@@ -48,7 +48,7 @@ def update_outlet_state(buttonNumber):
 
     statestorage.set_state(buttonNumber, state)
     codesender.sendCode.queue(buttonNumber, state)
-    
+
     if request.is_json:
         return jsonify({"state" : statestorage.get_state(buttonNumber)}) 
     else:
@@ -56,4 +56,4 @@ def update_outlet_state(buttonNumber):
 
 if __name__ == "__main__":
     app.debug = True
-    app.run(host="0.0.0.0",port=5000)
+    app.run(host="0.0.0.0",port=443)


### PR DESCRIPTION
Added the JSON response to JSON enabled GET, PUT and POST requests.

This was done in order to properly persist the last known state of the RF switch after Home Assistant's reboots or other scenarios